### PR TITLE
feat: add support to Symfony ^4.0 and ^5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 
 php:
-  - 7.1
+  - 7.2
   
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -6,10 +6,10 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=7.1",
-        "symfony/form": "^2.8 || ^3.0 || ^4.0",
-        "symfony/routing": "^2.8 || ^3.0 || ^4.0",
-        "symfony/framework-bundle": "^2.8 || ^3.0 || ^4.0",
-        "symfony/security": "^3.2 || ^4.0",
+        "symfony/form": "^2.8 || ^3.0 || ^4.0 || ^5.0",
+        "symfony/routing": "^2.8 || ^3.0 || ^4.0 || ^5.0",
+        "symfony/framework-bundle": "^2.8 || ^3.0 || ^4.0 || ^5.0",
+        "symfony/security": "^3.2 || ^4.0 || ^5.0",
         "symfony/templating": "^3.2"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         "symfony/routing": "^2.8 || ^3.0 || ^4.0 || ^5.0",
         "symfony/framework-bundle": "^2.8 || ^3.0 || ^4.0 || ^5.0",
         "symfony/security": "^3.2 || ^4.0 || ^5.0",
-        "symfony/templating": "^3.2"
+        "symfony/templating": "^3.2",
+        "twig/twig": "^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0 || ^7.0 || ^8.0",

--- a/composer.json
+++ b/composer.json
@@ -6,9 +6,9 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=7.1",
-        "symfony/form": "^2.8|^3.0",
-        "symfony/routing": "^2.8|^3.0",
-        "symfony/framework-bundle": "^2.8|^3.0",
+        "symfony/form": "^2.8 || ^3.0 || ^4.0",
+        "symfony/routing": "^2.8 || ^3.0 || ^4.0",
+        "symfony/framework-bundle": "^2.8 || ^3.0 || ^4.0",
         "symfony/security": "^3.2 || ^4.0",
         "symfony/templating": "^3.2"
     },

--- a/src/Controller/FlashMessageAware.php
+++ b/src/Controller/FlashMessageAware.php
@@ -27,7 +27,6 @@ trait FlashMessageAware
      * Adds a flash message to the current session for type.
      *
      * @param string $severity ['success', 'notice', 'warning', 'error']
-     * @param string $message
      */
     protected function addFlash(string $severity, string $message): void
     {

--- a/src/Controller/TwigAware.php
+++ b/src/Controller/TwigAware.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Linio\Common\Symfony\Controller;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Twig\Environment as Twig;
+
+trait TwigAware
+{
+    /**
+     * @var Twig
+     */
+    protected $twig;
+
+    public function getTwig(): Twig
+    {
+        return $this->twig;
+    }
+
+    public function setTwig(Twig $twig): void
+    {
+        $this->twig = $twig;
+    }
+
+    public function renderView(string $view, array $context = []): string
+    {
+        return $this->twig->render($view, $context);
+    }
+
+    public function render(string $view, array $context = [], Response $response = null): Response
+    {
+        $content = $this->twig->render($view, $context);
+
+        if ($response === null) {
+            $response = new Response();
+        }
+
+        $response->setContent($content);
+
+        return $response;
+    }
+
+    public function stream(string $view, array $context = [], StreamedResponse $response = null): StreamedResponse
+    {
+        $twig = $this->twig;
+
+        $callback = function () use ($twig, $view, $context): void {
+            $twig->display($view, $context);
+        };
+
+        if ($response === null) {
+            return new StreamedResponse($callback);
+        }
+
+        $response->setCallback($callback);
+
+        return $response;
+    }
+}

--- a/tests/Controller/TwigAwareTest.php
+++ b/tests/Controller/TwigAwareTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Linio\Common\Symfony\Controller;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Twig\Environment;
+
+class TwigAwareTest extends TestCase
+{
+    public function testIsSettingTwig(): void
+    {
+        $twig = $this->prophesize(Environment::class);
+
+        $controller = new class() {
+            use TwigAware;
+
+            public function test()
+            {
+                return $this->getTwig();
+            }
+        };
+        $controller->setTwig($twig->reveal());
+
+        $actual = $controller->test();
+
+        $this->assertInstanceOf(Environment::class, $actual);
+    }
+
+    public function testIsRenderingView(): void
+    {
+        $twig = $this->prophesize(Environment::class);
+        $twig->render('view', ['parameters' => 'parameters'])
+            ->willReturn('rendered_view');
+
+        $controller = new class() {
+            use TwigAware;
+
+            public function test($view, $parameters)
+            {
+                return $this->renderView($view, $parameters);
+            }
+        };
+        $controller->setTwig($twig->reveal());
+
+        $actual = $controller->test('view', ['parameters' => 'parameters']);
+
+        $this->assertSame('rendered_view', $actual);
+    }
+
+    public function testIsRenderingAResponse(): void
+    {
+        $twig = $this->prophesize(Environment::class);
+        $twig->render('view', ['parameters' => 'parameters'])
+            ->shouldBeCalled()
+            ->willReturn('rendered_view');
+
+        $controller = new class() {
+            use TwigAware;
+
+            public function test($view, $parameters)
+            {
+                return $this->render($view, $parameters);
+            }
+        };
+        $controller->setTwig($twig->reveal());
+
+        $actual = $controller->test('view', ['parameters' => 'parameters']);
+
+        $this->assertInstanceOf(Response::class, $actual);
+        $this->assertSame('rendered_view', $actual->getContent());
+    }
+
+    public function testIsStreaming(): void
+    {
+        $twig = $this->prophesize(Environment::class);
+
+        $controller = new class() {
+            use TwigAware;
+
+            public function test($view, $parameters)
+            {
+                return $this->stream($view, $parameters);
+            }
+        };
+        $controller->setTwig($twig->reveal());
+
+        $actual = $controller->test('view', ['parameters' => 'parameters']);
+
+        $this->assertInstanceOf(StreamedResponse::class, $actual);
+    }
+}


### PR DESCRIPTION
A trait for Twig was added, Twig service is not following any interface now and updating the actual `TemplatingAware` didn't seemed Ok to me since the `EngineInterface` interface will be removed in Symfony 5. Anyway this is just a proposal and any ideas are welcome.