### PR TITLE
revert: namespace for the templating bundle

### DIFF
--- a/src/Controller/TemplatingAware.php
+++ b/src/Controller/TemplatingAware.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Linio\Common\Symfony\Controller;
 
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;
-use Symfony\Component\Templating\EngineInterface;
 
 trait TemplatingAware
 {


### PR DESCRIPTION
Reverting: https://github.com/LinioIT/common-symfony/pull/21

The update of the namespace for the templating bundle is generating an error in the tests since the Templating component doesn't have the method `renderResponse` in its `EngineInterface` interface.

```
There was 1 error:

1) Linio\Common\Symfony\Controller\TemplatingAwareTest::testIsRenderingAResponse
Prophecy\Exception\Doubler\MethodNotFoundException: Method `Double\EngineInterface\P8::renderResponse()` is not defined.

/linio/common-symfony/tests/Controller/TemplatingAwareTest.php:57
```

Templating Bundle:
https://github.com/symfony/framework-bundle/blob/4.3/Templating/EngineInterface.php

Templating Component:
https://github.com/symfony/templating/blob/master/EngineInterface.php

BTW, we need to pay attention to that since we have plans to update some services for Symfony 5.0 https://symfony.com/blog/new-in-symfony-4-3-deprecated-the-templating-component-integration